### PR TITLE
Adding jena dependency config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target
 .settings
 .wtpmodules
 *.jnl
+cavendish-jetty/run.sh

--- a/cavendish-jetty/pom.xml
+++ b/cavendish-jetty/pom.xml
@@ -40,7 +40,7 @@
 		  <configuration>
 		  <mainClass>cavendish.jetty.App</mainClass>
         <cleanupDaemonThreads>false</cleanupDaemonThreads>
-        <environmentVariables>-Dcom.bigdata.rdf.sail.webapp.ConfigParams.propertyFile=src/main/webapp/WEB-INF/RWStore.properties</environmentVariables>
+        <environmentVariables>-Dcom.bigdata.rdf.sail.webapp.ConfigParams.propertyFile=src/main/webapp/WEB-INF/RWStore.properties -Dcom.bigdata.journal.AbstractJournal.file=target/bg.jnl</environmentVariables>
 		    <arguments>
 		      <argument>8080</argument>
 		      <argument>kb</argument>
@@ -106,6 +106,12 @@
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jaxrs</artifactId>
       <version>3.0.8.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>apache-jena-libs</artifactId>
+      <version>3.1.0</version>
+      <type>pom</type>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
I needed to add the Jena dependency config to get `cavendish-jetty` to compile.  Once compiled, I wasn't able to get it to run using https://gist.github.com/barmintor/85ca8158e98220c689a967075a2809af#file-run-sh however.  I tried various ways of supplying the com.bigdata.journal.AbstractJournal.file argument, but kept getting the error `Caused by: java.lang.RuntimeException: Required property: 'com.bigdata.journal.AbstractJournal.file'`
