### PR TITLE
Change IANA namespace

### DIFF
--- a/cavendish-blazegraph/src/main/java/cavendish/blazegraph/task/DirectContainerInsertedTriples.java
+++ b/cavendish-blazegraph/src/main/java/cavendish/blazegraph/task/DirectContainerInsertedTriples.java
@@ -16,7 +16,7 @@ public class DirectContainerInsertedTriples implements BiFunction<URI, BigdataSa
   private static final String SPARQL =
       "SELECT ?memberRelation ?member \n" +
       "WHERE { \n" +
-      "  GRAPH <info:cavendish/> { ?container <http://www.iana.org/assignments/link-relations/type> <http://www.w3.org/ns/ldp#DirectContainer> } .\n" +
+      "  GRAPH <info:cavendish/> { ?container <http://www.iana.org/assignments/relation/type> <http://www.w3.org/ns/ldp#DirectContainer> } .\n" +
       "  ?container <http://www.w3.org/ns/ldp#membershipResource> <%s> .\n" +
       "  ?container <http://www.w3.org/ns/ldp#contains> ?member .\n" +
       "  ?container <http://www.w3.org/ns/ldp#hasMemberRelation> ?memberRelation" +

--- a/cavendish-blazegraph/src/main/java/cavendish/blazegraph/task/IndirectContainerInsertedTriples.java
+++ b/cavendish-blazegraph/src/main/java/cavendish/blazegraph/task/IndirectContainerInsertedTriples.java
@@ -16,7 +16,7 @@ public class IndirectContainerInsertedTriples implements BiFunction<URI, Bigdata
   private static final String SPARQL =
       "SELECT ?memberRelation ?member \n" +
       "WHERE { \n" +
-      "  GRAPH <info:cavendish/> { ?container <http://www.iana.org/assignments/link-relations/type> <http://www.w3.org/ns/ldp#IndirectContainer> } .\n" +
+      "  GRAPH <info:cavendish/> { ?container <http://www.iana.org/assignments/relation/type> <http://www.w3.org/ns/ldp#IndirectContainer> } .\n" +
       "  ?container <http://www.w3.org/ns/ldp#membershipResource> <%s> .\n" +
       "  ?container <http://www.w3.org/ns/ldp#contains> ?proxy .\n" +
       "  ?container <http://www.w3.org/ns/ldp#insertedContentRelation> ?proxyRel .\n" +

--- a/cavendish-ldp/src/main/java/cavendish/ldp/api/Vocabulary.java
+++ b/cavendish-ldp/src/main/java/cavendish/ldp/api/Vocabulary.java
@@ -12,7 +12,7 @@ public interface Vocabulary {
   URI DELETED = LDP.resolve("#DeletedResource");
   URI DIRECT_CONTAINER = LDP.resolve("#DirectContainer");
   URI HAS_MEMBER_RELATION = LDP.resolve("#hasMemberRelation");
-  URI IANA_TYPE = URI.create("http://www.iana.org/assignments/link-relations/type");
+  URI IANA_TYPE = URI.create("http://www.iana.org/assignments/relation/type");
   URI INDIRECT_CONTAINER = LDP.resolve("#IndirectContainer");
   URI INSERTED_CONTENT_RELATION = LDP.resolve("#insertedContentRelation");
   URI INTERNAL_CONTEXT = URI.create("info:cavendish/");


### PR DESCRIPTION
According to the examples in [RFC 5988](https://tools.ietf.org/html/rfc5988#appendix-B) and [RFC 4287](https://tools.ietf.org/search/rfc4287#section-4.2.7), the IANA namespace should be http://www.iana.org/assignments/relation/

This PR changes the instances of .../link-relations/ to ../relation/
